### PR TITLE
Account for spaces in filepaths when running external MATLAB code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.6.4 - 2021-04-06
+
+### Fixed
+
+- Incorrect filepath provided to external MATLAB code. Now protects against paths with spaces in filepath.
+
 ## v1.6.3 - 2021-01-19
 
 ### Changed

--- a/xrcap/rootCrownImageAnalysis3D.py
+++ b/xrcap/rootCrownImageAnalysis3D.py
@@ -273,7 +273,7 @@ def process(args, fp, subfolder, thickness, scale, depth, pos, pbar_position):
                 if stderr:
                     logging.error(f'[stderr]\n{stderr.decode()}')
 
-            biomass_hist, convexhull_hist = asyncio.run(process_kde_with_matlab(f"kde-traits {os.path.join(fp, subfolder)} {thickness} {args.sampling}"))
+            biomass_hist, convexhull_hist = asyncio.run(process_kde_with_matlab(f"kde-traits '{os.path.join(fp, subfolder)}' {thickness} {args.sampling}"))
 
         if len(solidity) < depth:
             solidity = np.append(solidity, np.zeros(int(depth-len(solidity)))) # pad with zeros for missing depth values


### PR DESCRIPTION
Added surrounding single quotes to command used to start child process to run MATLAB code.

Single quotes were used to avoid potential variable expansion by the user's shell.

Resolves #31 